### PR TITLE
ci(travis): require Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - '6'
-  - '7'
   - '8'
   - '9'
   - '10'


### PR DESCRIPTION
Build failed for both Node.js version 6 and 7.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>

cc @bnjjj 