### PR TITLE
Update request functions to handle 201/204 success status codes

### DIFF
--- a/lib/ovh.es5.js
+++ b/lib/ovh.es5.js
@@ -401,7 +401,7 @@ var Ovh = function () {
             _this2.debug('[OVH] API response to', options.method, options.path, ':', body);
           }
 
-          if (res.statusCode !== 200) {
+          if (res.statusCode > 299 || res.statusCode < 200) {
             callback(res.statusCode, response ? response.message : response);
           } else {
             // Return a proxy (for potential next request)

--- a/lib/ovh.es6.js
+++ b/lib/ovh.es6.js
@@ -405,7 +405,7 @@ class Ovh {
           );
         }
 
-        if (res.statusCode !== 200) {
+        if (res.statusCode > 299 || res.statusCode < 200) {
           callback(res.statusCode, response ? response.message : response);
         }
         else {


### PR DESCRIPTION
For example, the `/domain/zone/{zoneName}/record/{id}` `DELETE` route now returns a 204 success status code, but this lib throws an exception because of that. 